### PR TITLE
Only logging the QUERY_STRING value if there is one. This fixes #6.

### DIFF
--- a/app/Http/Middleware/DebugRequest.php
+++ b/app/Http/Middleware/DebugRequest.php
@@ -16,7 +16,13 @@ class DebugRequest
      */
     public function handle($request, Closure $next)
     {
-        Log::notice('Hit: ' . $request->url() . ' ?' . $_SERVER['QUERY_STRING']);
+
+        if (!empty($_SERVER['QUERY_STRING'])) {
+            Log::notice('Hit: ' . $request->url() . ' ?' . $_SERVER['QUERY_STRING']);
+        } else {
+            Log::notice('Hit: ' . $request->url());
+        }
+
         return $next($request);
     }
 }


### PR DESCRIPTION
Conditionally logging the `QUERY_STRING` value if there is one. This should fix #6.